### PR TITLE
Get Sentinel-1 data similar to ETCI2021 competition

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "[python]": {
     "editor.rulers": [110],
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     },
     "editor.defaultFormatter": "charliermarsh.ruff"
   },

--- a/poetry.lock
+++ b/poetry.lock
@@ -1576,6 +1576,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/src/flood_mapping/download_hyp3.py
+++ b/src/flood_mapping/download_hyp3.py
@@ -1,4 +1,8 @@
 import os
+import tempfile
+import time
+from pathlib import Path
+from shutil import unpack_archive
 
 import dotenv
 import requests
@@ -8,7 +12,7 @@ dotenv.load_dotenv()
 HYP3_COOKIE = os.environ["HYP3_COOKIE"]
 
 
-def make_hyp3_request(url):
+def make_hyp3_request(endpoint, method="GET", **kwargs):
     """Make a request to the HYP3 API with the required cookie.
 
     To get the cookie:
@@ -30,15 +34,86 @@ def make_hyp3_request(url):
     cookies = {
         "asf-urs": HYP3_COOKIE,
     }
-
-    response = requests.get(url, cookies=cookies)
+    url = "https://hyp3-api.asf.alaska.edu/" + endpoint
+    response = requests.request(method, url, cookies=cookies, **kwargs)
     return response.json()
 
 
 def try_user_info():
-    url = "https://hyp3-api.asf.alaska.edu/v1/users/info"
-    return make_hyp3_request(url)
+    endpoint = "user"
+    return make_hyp3_request(endpoint)
+
+
+def run_vv_vh_job(scene_name):
+    """Submit a job, wait for it to finish, and download the results."""
+    response = submit_vv_vh_job(scene_name)
+    job_id = response["jobs"][0]["job_id"]
+    response = wait_to_finish(job_id)
+    download_url = response["files"][0]["url"]
+    download_data(download_url)
+
+
+def submit_vv_vh_job(scene_name):
+    """Submit a job to the HYP3 API to process a Sentinel-1 scene to VV and VH backscatter."""
+    data = {
+        "jobs": [
+            {
+                "job_parameters": {
+                    "dem_matching": False,
+                    "dem_name": "copernicus",
+                    "granules": [scene_name],
+                    "include_dem": False,
+                    "include_inc_map": False,
+                    "include_rgb": False,
+                    "include_scattering_area": False,
+                    "radiometry": "gamma0",
+                    "resolution": 20,
+                    "scale": "power",
+                    "speckle_filter": False,
+                },
+                "job_type": "RTC_GAMMA",
+                "name": f"RTC Job for {scene_name}",
+            },
+        ],
+        "validate_only": False,
+    }
+    endpoint = "jobs"
+    response = make_hyp3_request(endpoint, method="POST", json=data)
+    return response
+
+
+def wait_to_finish(job_id):
+    """Wait for a job to finish and return the response."""
+    status = "RUNNING"
+    while True:
+        endpoint = f"jobs/{job_id}"
+        response = make_hyp3_request(endpoint)
+        try:
+            status = response["status_code"]
+        except (KeyError, IndexError) as e:
+            print("status could not be fetched from:", response)
+            raise e
+        if status == "RUNNING":
+            print("Job is still running")
+            time.sleep(60)
+        else:
+            break
+    return response
+
+
+def download_data(url):
+    """Download the processed HYP3 zip (1GB) and extract it to data"""
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_file_path = Path(temp_dir) / "download.zip"
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        with temp_file_path.open("wb") as temp_file:
+            for chunk in response.iter_content(chunk_size=8192):
+                temp_file.write(chunk)
+        unpack_archive(temp_file_path, "data")
 
 
 if __name__ == "__main__":
     print(try_user_info())
+    scene_name = "S1A_IW_GRDH_1SDV_20231228T173337_20231228T173402_051858_0643CB_C0B6"

--- a/src/flood_mapping/download_hyp3.py
+++ b/src/flood_mapping/download_hyp3.py
@@ -1,0 +1,44 @@
+import os
+
+import dotenv
+import requests
+
+dotenv.load_dotenv()
+
+HYP3_COOKIE = os.environ["HYP3_COOKIE"]
+
+
+def make_hyp3_request(url):
+    """Make a request to the HYP3 API with the required cookie.
+
+    To get the cookie:
+    1. Log in the HYP3 website:
+        https://search.asf.alaska.edu/
+    2. Go to the swagger API documentation:
+        https://hyp3-api.asf.alaska.edu/ui/
+    3. Open the developer tools in the browser and go to the network tab.
+    4. Make a request to the GET `/user` endpoint.
+    5. Right click the request in the dev tools and select "Copy" -> "Copy as cURL (bash)".
+    6. Paste the cURL command in a text editor and copy the part of the command between `asf-urs=` and the next semicolon.
+
+    Args:
+        url (str): The URL to make the request to.
+
+    Returns:
+        dict: The JSON response from the request.
+    """
+    cookies = {
+        "asf-urs": HYP3_COOKIE,
+    }
+
+    response = requests.get(url, cookies=cookies)
+    return response.json()
+
+
+def try_user_info():
+    url = "https://hyp3-api.asf.alaska.edu/v1/users/info"
+    return make_hyp3_request(url)
+
+
+if __name__ == "__main__":
+    print(try_user_info())


### PR DESCRIPTION
The ETCI competition used hyp3, which is documented here:
https://hyp3-docs.asf.alaska.edu/using/api/

You can use a UI to search for scenes and create jobs:
https://search.asf.alaska.edu/

From Python the same can be done using the API:
https://hyp3-api.asf.alaska.edu/ui/

ChatGPT helped determine what settings ETCI2021 used:

> To configure your RTC processing options to be most similar to the ETCI2021 data, you should use the following settings:
> 
> Radiometry: Select gamma0 since the ETCI2021 data used this normalization for their SAR imagery.
> Scale: Use the power scale as the imagery was provided in power rather than in dB (decibel).
> Pixel Spacing: Choose a native resolution that matches Sentinel-1's Interferometric Wide Swath mode, which has a resolution of approximately 5x20 meters. The ETCI2021 dataset used 256x256 pixel tiles, but the specific pixel spacing for your RTC processing will depend on the capabilities of the HyP3 tool and the native resolution of the imagery you are working with.
> For other settings such as speckle filtering, DEM inclusion, or other additional layers, these would be optional and based on your analytical needs. The ETCI2021 data itself was processed with HyP3 to create consistent VV/VH amplitude or power imagery and then converted to 8-bit grayscale images.

The new functions allow creating jobs to process data in this way and to download the result. The input right now is the name of a scene, e.g. `S1A_IW_GRDH_1SDV_20240101T055014_20240101T055039_051909_064584_8DE8`. We can probably use the Sentinel/Copernicus API to find relevant scenes for flood events.

The data returned is for the whole scene, which is a big area, further preprocessing is needed to crop the data and to potentially turn it into the same format as ETCI. The data we get is 2 large tif files, 1 VV and 1 VH.